### PR TITLE
update code comments to reflect actual account_key requirements (fog …

### DIFF
--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -739,7 +739,7 @@ pub extern "C" fn mc_transaction_builder_build(
 
 /// # Preconditions
 ///
-/// * `account_key` - must be a valid `AccountKey` with `fog_info`.
+/// * `account_key` - must be a valid `AccountKey`
 #[no_mangle]
 pub extern "C" fn mc_memo_builder_sender_and_destination_create(
     account_key: FfiRefPtr<McAccountKey>,
@@ -758,7 +758,7 @@ pub extern "C" fn mc_memo_builder_sender_and_destination_create(
 
 /// # Preconditions
 ///
-/// * `account_key` - must be a valid `AccountKey` with `fog_info`.
+/// * `account_key` - must be a valid `AccountKey`
 #[no_mangle]
 pub extern "C" fn mc_memo_builder_sender_payment_request_and_destination_create(
     payment_request_id: u64,
@@ -779,7 +779,7 @@ pub extern "C" fn mc_memo_builder_sender_payment_request_and_destination_create(
 
 /// # Preconditions
 ///
-/// * `account_key` - must be a valid `AccountKey` with `fog_info`.
+/// * `account_key` - must be a valid `AccountKey`
 #[no_mangle]
 pub extern "C" fn mc_memo_builder_sender_payment_intent_and_destination_create(
     payment_intent_id: u64,


### PR DESCRIPTION
### Motivation

Code comments for the "memo builder" create suggest that account_keys must have fog_info to be valid, this is not correct, any valid account_key will work even those without fog_info. 

This can be verified by reviewing the unit-tests in `mobilecoin`, the account_keys used do not have fog_info:

https://github.com/mobilecoinfoundation/mobilecoin/blob/master/transaction/extra/src/memo/mod.rs#L132

```rust
    fn test_memo_type_round_trips() {
        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);

        let alice = AccountKey::new(
            &RistrettoPrivate::from_random(&mut rng),
            &RistrettoPrivate::from_random(&mut rng),
        );
        let alice_cred = SenderMemoCredential::from(&alice);

        let bob = AccountKey::new(
            &RistrettoPrivate::from_random(&mut rng),
            &RistrettoPrivate::from_random(&mut rng),
        );
        let bob_addr = bob.default_subaddress();

        let tx_public_key = CompressedRistrettoPublic::from_random(&mut rng);

        let memo1 = UnusedMemo {};
        match MemoType::try_from(&MemoPayload::from(memo1)).unwrap() {
            MemoType::Unused(_) => {}
            _ => {
                panic!("unexpected deserialization");
            }
        }

....


```

### In this PR
* Update code comments to reflect actual implementation requirements

