### PR TITLE
Use Xcode 12.5.1 in CICD for GRPC Unit Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,7 +847,7 @@ workflows:
             - make-generate
           matrix:
             parameters:
-              xcode-version: [*default-xcode-version]
+              xcode-version: ["12.5.1"]
 
       - publish-pod-release:
           filters:


### PR DESCRIPTION
Soundtrack of this PR: [Anz - Inna Step](https://soundcloud.com/yung-anz/inna-circle?in=ninja-tune/sets/anz-you-could-be-ft-george)

### Motivation

GRPC dependencies will compile w/ 12.5.1 so setting that explicitly for the tests that need it.

### In this PR
* use Xcode 12.5.1 for GRPC based unit tests

### Future Work
* Find long-term fix for compilation issue by contacting cocoapods, or switching to SPM 

