### PR TITLE
Optimize artifacts submodule strategy

### DIFF
--- a/LibMobileCoin.podspec
+++ b/LibMobileCoin.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "LibMobileCoin"
-  s.version      = "5.0.5"
+  s.version      = "5.0.6"
   s.summary      = "A library for communicating with MobileCoin network"
 
   s.author       = "MobileCoin"

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ push-generated:
 
 # Release
 
+# When we merge feature branches into master, we should squash-merge the Artifacts branch
+# into Artifacts origin/main. This gives a concise history, and lets us remove old 
+# feature branches from Artifacts without remove commit-hashes that libmobilecoin
+# may be pointing too.
 .PHONY: save-release-artifacts
 save-release-artifacts:
 	@[[ "$$(git rev-parse --abbrev-ref HEAD)" == "master" ]] || \

--- a/Makefile
+++ b/Makefile
@@ -134,12 +134,16 @@ save-release-artifacts:
 		git rebase -X theirs main && \
 		git checkout main && \
 		git merge -X theirs --squash pre-squash-artifacts; \
-		if [ git diff-index --quiet --cached HEAD ]; \
-		then \
-    	echo "Empty"; \
-  	else \
-    	echo "Not empty"; \
-  	fi
+		if [ git diff-index --quiet --cached HEAD ]; then \
+			echo "No changes in Artifacts staging area."; \
+		else \
+			echo "Changes found in Artifacts staging area."; \
+			git commit -m '[skip ci] Add artifacts to main branch'; \
+			git push origin main; \
+			cd .. && \
+			git add Artifacts && \
+			git commit -m '[skip ci] Update Artifacts commit after squashing latest Artifacts into its origin/main branch.' \
+		fi
 	
 
 .PHONY: check-condition

--- a/Makefile
+++ b/Makefile
@@ -129,20 +129,27 @@ save-release-artifacts:
 		git checkout -b pre-squash-artifacts && \
 		git remote set-branches --add origin main && \
 		git fetch && \
-		git checkout -b main --track origin/main
-		git checkout pre-squash-artifacts
+		git checkout -b main --track origin/main || true \
+		git checkout pre-squash-artifacts && \
 		git rebase -X theirs main && \
 		git checkout main && \
-		git merge -X theirs --squash pre-squash-artifacts && \
-		if git diff-index --quiet --cached HEAD; then \
-    	echo "No changes in staging area."\
-		else \
-  		echo "Changes found in staging area." && \
-	  	git commit -m '[skip ci] Add artifacts to main branch' && \
-	  	git push origin main \
-		fi \
-		echo "complete"
+		git merge -X theirs --squash pre-squash-artifacts; \
+		if [ git diff-index --quiet --cached HEAD ]; \
+		then \
+    	echo "Empty"; \
+  	else \
+    	echo "Not empty"; \
+  	fi
 	
+
+.PHONY: check-condition
+check-condition:
+	@if [ -d "my_directory" ]; then \
+		echo "Directory exists."; \
+	else \
+		echo "Directory does not exist."; \
+	fi
+
 .PHONY: tag-release
 tag-release:
 	@[[ "$$(git rev-parse --abbrev-ref HEAD)" == "master" ]] || \

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ save-release-artifacts:
 			git push origin main; \
 			cd .. && \
 			git add Artifacts && \
-			git commit -m '[skip ci] Update Artifacts commit after squashing latest Artifacts into its origin/main branch.' \
+			git commit -m '[skip ci] Update Artifacts commit after squashing latest Artifacts into its origin/main branch.'; \
 		fi
 	
 

--- a/Makefile
+++ b/Makefile
@@ -149,15 +149,6 @@ save-release-artifacts:
 			git commit -m '[skip ci] Update Artifacts commit after squashing latest Artifacts into its origin/main branch.'; \
 		fi
 	
-
-.PHONY: check-condition
-check-condition:
-	@if [ -d "my_directory" ]; then \
-		echo "Directory exists."; \
-	else \
-		echo "Directory does not exist."; \
-	fi
-
 .PHONY: tag-release
 tag-release:
 	@[[ "$$(git rev-parse --abbrev-ref HEAD)" == "master" ]] || \

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ push-generated:
 
 # When we merge feature branches into master, we should squash-merge the Artifacts branch
 # into Artifacts origin/main. This gives a concise history, and lets us remove old 
-# feature branches from Artifacts without remove commit-hashes that libmobilecoin
+# feature branches from Artifacts without removing commit-hashes that libmobilecoin
 # may be pointing too.
 .PHONY: save-release-artifacts
 save-release-artifacts:


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

I want to simplify the artifacts submodule and its relation to libmobilecoin. The current setup could create feature-branches in CICD with long histories, and then upon merge to master, we're essentially keeping these branches by tracking the commit in libmobilecoin.

The new solution is to rebase whatever commit is being pointed to onto `origin/main` accepting all new changes, and the squash-merging. This compresses all new changes from the CICD feature branch to one commit. 

### In this PR
* update the Makefile, leave a comment
* update version to trigger new release.

### Future Work
* < Out of scope non-goals for this PR >
* < These should be links to tickets. If the tickets do not exist, make them. >

